### PR TITLE
Fix for links on practice section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@
 | Раздел                  | Материал                                       |
 | ----------------------- | ---------------------------------------------- |
 | ruby                    | <https://www.rubykoans.com>                                   |
-| основы git              | [https://git-scm.com/book/ru/v2/Основы-Git-Создание-Git-репозитория](https://sql-academy.org/ru/trainer)  |
+| основы git              | [Создание Git-репозитория](https://git-scm.com/book/ru/v2/Основы-Git-Создание-Git-репозитория) |
+| Основы SQL              | [Тренажёр от SQL Academy](https://sql-academy.org/ru/trainer)  |
 
 
 


### PR DESCRIPTION
В разделе практики две ссылки "превратились" в одну.